### PR TITLE
Fix for GCC 13.1.1

### DIFF
--- a/include/gzip/decompress.hpp
+++ b/include/gzip/decompress.hpp
@@ -4,6 +4,7 @@
 #include <zlib.h>
 
 // std
+#include <cstdint>
 #include <limits>
 #include <stdexcept>
 #include <string>


### PR DESCRIPTION
# Changes

Using GCC 13.1.1 compiler gives you a number of missing `cstdint` types errors. This PR fixes it.