### PR TITLE
Fix gzip const cast

### DIFF
--- a/include/gzip/compress.hpp
+++ b/include/gzip/compress.hpp
@@ -72,7 +72,7 @@ class Compressor
         }
 #pragma GCC diagnostic pop
 
-        deflate_s.next_in = reinterpret_cast<z_const Bytef*>(data);
+        deflate_s.next_in = reinterpret_cast<z_const Bytef*>(const_cast<z_const char*>(data));
         deflate_s.avail_in = static_cast<unsigned int>(size);
 
         std::size_t size_compressed = 0;

--- a/include/gzip/decompress.hpp
+++ b/include/gzip/decompress.hpp
@@ -51,7 +51,7 @@ class Decompressor
             throw std::runtime_error("inflate init failed");
         }
 #pragma GCC diagnostic pop
-        inflate_s.next_in = reinterpret_cast<z_const Bytef*>(data);
+        inflate_s.next_in = reinterpret_cast<z_const Bytef*>(const_cast<z_const char*>(data));
 
 #ifdef DEBUG
         // Verify if size (long type) input will fit into unsigned int, type used for zlib's avail_in


### PR DESCRIPTION
# Changes

`z_const` is a preprocessor variables that can either be blank or it can be `const`. When its a `const` things are okay, the code  runs the following statement:

```cpp
const char* data;
reinterpret_cast<const unsigned char*>(data);
```

However when `z_const` is blank, we perform a non implicit const cast which causes the compile to error out, essentially the statement looks like:

```cpp
const char* data;
reinterpret_cast<unsigned char*>(data);
```

And that is a problem. What the fix here does is make the const cast explicit. In the cast that the `z_const` is blank, the `const_cast` is a no-op and ignored, but on the instance that its something, we are explicit about our intent.

# Testing

We noticed this issue [here](https://github.com/swift-nav/orion/pull/8904) when trying to add gzip compression to our protobuf files, looks like adding `#include <google/protobuf/io/gzip_stream.h>` to a Orion `master` commit will cause a build failure. I've compiled the code with this fix and it doesn't branch anymore with/without the header file.